### PR TITLE
Seed Success Factors when creating projects

### DIFF
--- a/server/projectsDb.ts
+++ b/server/projectsDb.ts
@@ -10,6 +10,7 @@ import { db } from './db';
 import { eq, and, asc, sql } from 'drizzle-orm';
 import { projectTasks as projectTasksTable } from '@shared/schema';
 import { DEBUG_TASKS, DEBUG_FILES } from '@shared/constants.debug';
+import { cloneAllSuccessFactorTasks } from './cloneSuccessFactors';
 
 /**
  * Validates sourceId to ensure it's either a valid UUID or null
@@ -298,7 +299,13 @@ export const projectsDb = {
         completed: false,
         origin: 'custom'
       });
-      
+
+      try {
+        await cloneAllSuccessFactorTasks(projectId);
+      } catch (cloneError) {
+        console.error('Failed to clone Success Factor tasks:', cloneError);
+      }
+
       // Save project to file
       const projects = loadProjects();
       projects.push(project);

--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -8,6 +8,7 @@ import { isOrgMember } from "../middlewares/isOrgMember.js";
 import { isValidUUID, isNumericId, convertNumericIdToUuid } from "../utils/uuid-utils.js";
 import { v4 as uuidv4 } from 'uuid';
 import { projectsDb } from '../projectsDb.js';
+import { cloneAllSuccessFactorTasks } from '../cloneSuccessFactors.js';
 
 /**
  * Middleware to validate a project ID
@@ -411,14 +412,20 @@ router.post("/", isAuthenticated, async (req, res) => {
         lastUpdated: new Date()
       })
       .returning();
-    
+
     if (!newProject) {
       console.error(`Failed to create project for user ${userId}`);
       return res.status(500).json({ message: "Failed to create project" });
     }
-    
+
     console.log(`Successfully created project ${newProject.id} for user ${userId}`);
-    
+
+    try {
+      await cloneAllSuccessFactorTasks(newProject.id);
+    } catch (cloneErr) {
+      console.error("Error cloning Success Factor tasks:", cloneErr);
+    }
+
     // Clear the projects cache in the session if it exists
     if (req.user.projects) {
       delete req.user.projects;

--- a/tests/api/project-create-factors.spec.ts
+++ b/tests/api/project-create-factors.spec.ts
@@ -1,0 +1,62 @@
+import request from 'supertest';
+import express from 'express';
+import { registerRoutes } from '../../server/routes.ts';
+import { db } from '../../server/db';
+import { projects, projectTasks } from '@shared/schema';
+import { eq } from 'drizzle-orm';
+import * as factorsDb from '../../server/factorsDb';
+
+describe('Project creation clones Success Factor tasks', () => {
+  let app: express.Express;
+  let server: any;
+  const USER_ID = 777;
+  let projectId: string | undefined;
+
+  beforeAll(async () => {
+    app = express();
+    app.use(express.json());
+    server = await registerRoutes(app);
+
+    // mock auth
+    app.use((req: any, _res: any, next: any) => {
+      req.isAuthenticated = () => true;
+      req.user = { id: USER_ID };
+      next();
+    });
+  });
+
+  afterAll(async () => {
+    if (projectId) {
+      await db.delete(projectTasks).where(eq(projectTasks.projectId, projectId)).execute();
+      await db.delete(projects).where(eq(projects.id, projectId)).execute();
+    }
+
+    await new Promise<void>((resolve) => {
+      if (server && server.close) {
+        server.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  it('creates a project and seeds Success Factor tasks', async () => {
+    const res = await request(app).post('/api/projects').send({ name: 'SF clone test' });
+    expect(res.status).toBe(201);
+    projectId = res.body.id;
+    expect(projectId).toBeDefined();
+
+    const factors = await factorsDb.getFactors();
+    let expected = 0;
+    for (const factor of factors) {
+      for (const stage of Object.keys(factor.tasks)) {
+        expected += (factor.tasks as any)[stage]?.length || 0;
+      }
+    }
+
+    const tasks = await db.select().from(projectTasks).where(eq(projectTasks.projectId, projectId!));
+    const factorTasks = tasks.filter((t: any) => t.origin === 'factor');
+    expect(factorTasks.length).toBe(expected);
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure `projectsDb` clones Success Factor tasks when creating projects
- update the POST `/api/projects` route to clone Success Factor tasks
- test that project creation seeds all Success Factor tasks

## Testing
- `npx vitest run tests/api/project-create-factors.spec.ts` *(fails: Database connection string missing)*