### PR TITLE
Add UUID validation middleware

### DIFF
--- a/server/middleware/validateUuid.ts
+++ b/server/middleware/validateUuid.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from 'express';
+import { isValidUUID, isNumericId } from '../utils/uuid-utils.js';
+
+/**
+ * Factory to create middleware validating that specific request parameters are UUIDs.
+ * If a parameter is missing the middleware does not block the request.
+ * Numeric IDs are rejected with a specific error message to guard against
+ * legacy ID usage after the UUID migration.
+ */
+export function validateUuid(paramNames: string | string[]) {
+  const params = Array.isArray(paramNames) ? paramNames : [paramNames];
+
+  return function (req: Request, res: Response, next: NextFunction) {
+    for (const name of params) {
+      const value = req.params[name] ?? req.body?.[name];
+      if (!value) {
+        continue; // Only validate when a value is provided
+      }
+
+      if (isNumericId(value)) {
+        return res.status(400).json({
+          message: `Invalid ${name} format. Numeric IDs are no longer supported.`,
+          error: 'NUMERIC_ID_NOT_SUPPORTED',
+          [name]: value,
+        });
+      }
+
+      if (!isValidUUID(value)) {
+        return res.status(400).json({
+          message: `Invalid ${name} format. Must be a valid UUID.`,
+          error: 'INVALID_UUID_FORMAT',
+          [name]: value,
+        });
+      }
+    }
+
+    next();
+  };
+}
+
+export default validateUuid;

--- a/tests/api/task-toggle-scenarios.test.ts
+++ b/tests/api/task-toggle-scenarios.test.ts
@@ -76,7 +76,7 @@ describe('Task Toggle Endpoint Tests', () => {
   });
 
   // Test 3: Invalid UUID
-  it('should return 404 for invalid UUID', async () => {
+  it('should return 400 for invalid UUID', async () => {
     const response = await request(app)
       .put(`/api/projects/${PROJECT_ID}/tasks/not-a-valid-uuid`)
       .set('x-auth-override', 'true')
@@ -90,7 +90,7 @@ describe('Task Toggle Endpoint Tests', () => {
       body: response.body
     });
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(400);
   });
 
   // Test 4: Cross-project sourceId attempt

--- a/tests/unit/updateBySourceId.test.ts
+++ b/tests/unit/updateBySourceId.test.ts
@@ -139,7 +139,7 @@ describe('Task Update API Hardening Tests', () => {
     
     expect(res.status).toBe(400);
     expect(res.body.success).toBe(false);
-    expect(res.body.error).toBe('INVALID_FORMAT');
+    expect(res.body.error).toBe('INVALID_UUID_FORMAT');
   });
 
   // Scenario 5: Regular non-factor task updates still work


### PR DESCRIPTION
## Summary
- add `validateUuid` middleware
- use `validateUuid` in project and task routes
- update tests for new error handling

## Testing
- `npm test` *(fails: 46 failed, 9 passed)*