### PR TITLE
Fix organisation mapping

### DIFF
--- a/server/routes/organisations.js
+++ b/server/routes/organisations.js
@@ -38,7 +38,11 @@ router.get('/', async (req, res) => {
 
     // Map to return only the organization details with role
     const result = userOrganisations.map(membership => ({
-      ...membership.organisation,
+      id: membership.organisation.id,
+      name: membership.organisation.name,
+      description: membership.organisation.description,
+      createdAt: membership.organisation.createdAt,
+      updatedAt: membership.organisation.updatedAt,
       role: membership.role
     }));
 


### PR DESCRIPTION
## Summary
- map organisation fields explicitly when fetching user organisations

## Testing
- `npm run test:smoke` *(fails: SyntaxError: Cannot use import statement outside a module)*