### PR TITLE
Remove QuickAuthDebug overlay

### DIFF
--- a/client/src/layouts/AppLayout.tsx
+++ b/client/src/layouts/AppLayout.tsx
@@ -4,7 +4,6 @@ import SiteFooter from "@/components/SiteFooter";
 import { Breadcrumb } from "@/components/Breadcrumb";
 import ProjectBanner from "@/components/ProjectBanner";
 import { Toaster } from "@/components/ui/toaster";
-import { QuickAuthDebug } from "@/components/QuickAuthDebug";
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -26,7 +25,6 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
       </div>
       <SiteFooter />
       <Toaster />
-      <QuickAuthDebug />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the QuickAuthDebug import and component from `AppLayout`

## Testing
- `npm test` *(fails: vitest tests fail due to missing modules and AuthProvider issues)*