### PR TITLE
Handle missing Stripe key in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
 
     env:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY || 'sk_test_dummy' }}
 
     steps:
       - name: Checkout repository

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { forceJsonResponses } from "./middleware/forceJsonResponses";
 import { initializeServices } from "./services";
 import { projectsDb } from "./projectsDb";
 import organisationsRouter from "./routes/organisations.js";
+import { initializeStripe } from "./utils/stripe";
 
 const app = express();
 app.use(express.json());
@@ -64,6 +65,8 @@ process.on('uncaughtException', (error) => {
 });
 
 (async () => {
+  // Initialize Stripe if available
+  initializeStripe();
   // Run the factors integrity check using improved utilities
   try {
     console.log('Starting server initialization...');

--- a/server/utils/stripe.ts
+++ b/server/utils/stripe.ts
@@ -1,0 +1,29 @@
+import Stripe from 'stripe';
+
+let stripe: Stripe | null = null;
+
+/**
+ * Initialize the Stripe client.
+ * - In production, expects STRIPE_SECRET_KEY to be set and disables Stripe if missing.
+ * - In development/testing, uses a dummy key when STRIPE_SECRET_KEY is not provided.
+ */
+export function initializeStripe() {
+  if (stripe) return stripe;
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn('STRIPE_SECRET_KEY not set; Stripe features disabled');
+      return null;
+    }
+    // Use dummy key so Stripe library can be instantiated without hitting real APIs
+    stripe = new Stripe('sk_test_dummy', { apiVersion: '2023-10-16' });
+    console.log('Using dummy Stripe key for development/test');
+  } else {
+    stripe = new Stripe(key, { apiVersion: '2023-10-16' });
+  }
+  return stripe;
+}
+
+export function getStripe() {
+  return stripe;
+}


### PR DESCRIPTION
## Summary
- add Stripe init helper that uses a dummy key in non-production
- invoke `initializeStripe` during server startup
- configure workflow to supply a dummy `STRIPE_SECRET_KEY` by default

## Testing
- `npm test` *(fails: Cannot set properties of undefined (setting 'env'))*