### PR TITLE
Add UUID validation middleware

### DIFF
--- a/server/middleware/validateUuid.ts
+++ b/server/middleware/validateUuid.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction } from 'express';
+import { isValidUUID, isNumericId } from '../utils/uuid-utils.js';
+
+/**
+ * Factory to create middleware validating that specific request parameters are UUIDs.
+ * If a parameter is missing the middleware does not block the request.
+ * Numeric IDs are rejected with a specific error message to guard against
+ * legacy ID usage after the UUID migration.
+ */
+export function validateUuid(paramNames: string | string[]) {
+  const params = Array.isArray(paramNames) ? paramNames : [paramNames];
+
+  return function (req: Request, res: Response, next: NextFunction) {
+    for (const name of params) {
+      const value = req.params[name] ?? req.body?.[name];
+      if (!value) {
+        continue; // Only validate when a value is provided
+      }
+
+      if (isNumericId(value)) {
+        return res.status(400).json({
+          message: `Invalid ${name} format. Numeric IDs are no longer supported.`,
+          error: 'NUMERIC_ID_NOT_SUPPORTED',
+          [name]: value,
+        });
+      }
+
+      if (!isValidUUID(value)) {
+        return res.status(400).json({
+          message: `Invalid ${name} format. Must be a valid UUID.`,
+          error: 'INVALID_UUID_FORMAT',
+          [name]: value,
+        });
+      }
+    }
+
+    next();
+  };
+}
+
+export default validateUuid;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -31,7 +31,8 @@ import { projectsDb } from './projectsDb';
 // Import the task logger for detailed instrumentation
 import { taskLogger, TaskErrorCodes } from './services/taskLogger';
 import { taskStateManager } from './services/taskStateManager';
-import { getTaskIdResolver, TaskIdResolver, validateUuid } from './services/taskIdResolver';
+import { getTaskIdResolver, TaskIdResolver } from './services/taskIdResolver';
+import validateUuid from './middleware/validateUuid';
 
 // Add type augmentation for projectsDb to include the missing methods
 declare module './projectsDb' {
@@ -817,7 +818,10 @@ app.get('/api/debug/errors', async (req: Request, res: Response) => {
   });
 
   // Task update endpoint with guaranteed JSON responses and proper Success Factor handling
-  app.put("/api/projects/:projectId/tasks/:taskId", async (req: Request, res: Response) => {
+  app.put(
+    "/api/projects/:projectId/tasks/:taskId",
+    validateUuid(["projectId", "taskId"]),
+    async (req: Request, res: Response) => {
     // CRITICAL: First action - Always set Content-Type header for JSON responses
     res.setHeader('Content-Type', 'application/json; charset=utf-8');
     
@@ -922,22 +926,6 @@ app.get('/api/debug/errors', async (req: Request, res: Response) => {
       const taskIdResolver = getTaskIdResolver(projectsDb);
       
       // Validate the input task ID format using cleanUUID method
-      if (taskId && !validateUuid(taskIdResolver.cleanUUID(taskId))) {
-        const error = new Error(`Invalid task ID format: ${taskId}`);
-        taskLogger.endOperation(operationId, false, error);
-        
-        if (isDebugEnabled) {
-          console.log(`[DEBUG_TASKS] Invalid task ID format: ${taskId}`);
-        }
-        
-        return res.status(400).json(
-          taskLogger.formatErrorResponse(
-            TaskErrorCodes.VALIDATION_ERROR,
-            `Invalid task ID format: ${taskId}`,
-            { taskId, projectId }
-          )
-        );
-      }
       
       // Use the TaskIdResolver with proper database connection to find the task
       // with intelligent ID resolution and proper parameter order (taskId, projectId)

--- a/server/routes/projects.js
+++ b/server/routes/projects.js
@@ -5,7 +5,8 @@ import { z } from "zod";
 import { eq } from "drizzle-orm";
 import { isAuthenticated } from "../middlewares/isAuthenticated.js";
 import { isOrgMember } from "../middlewares/isOrgMember.js";
-import { isValidUUID, isNumericId, convertNumericIdToUuid } from "../utils/uuid-utils.js";
+import { isNumericId, convertNumericIdToUuid } from "../utils/uuid-utils.js";
+import validateUuid from "../middleware/validateUuid";
 import { v4 as uuidv4 } from 'uuid';
 import { projectsDb } from '../projectsDb.js';
 
@@ -13,37 +14,6 @@ import { projectsDb } from '../projectsDb.js';
  * Middleware to validate a project ID
  * This ensures only UUID format project IDs are accepted
  */
-function validateProjectId(req, res, next) {
-  const projectId = req.params.projectId || req.params.id || req.body.projectId;
-  
-  if (!projectId) {
-    // ID wasn't provided, proceed to next middleware (which may handle the error)
-    return next();
-  }
-  
-  // Check if it's a numeric ID
-  if (isNumericId(projectId)) {
-    console.error(`Rejected request with numeric project ID: ${projectId}`);
-    return res.status(400).json({ 
-      message: "Invalid project ID format. Numeric IDs are no longer supported.", 
-      error: "NUMERIC_ID_NOT_SUPPORTED",
-      projectId
-    });
-  }
-  
-  // Check if it's a valid UUID
-  if (!isValidUUID(projectId)) {
-    console.error(`Rejected request with invalid project ID format: ${projectId}`);
-    return res.status(400).json({ 
-      message: "Invalid project ID format. Must be a valid UUID.", 
-      error: "INVALID_UUID_FORMAT",
-      projectId
-    });
-  }
-  
-  // Valid UUID provided, continue
-  next();
-}
 
 const router = express.Router();
 
@@ -109,7 +79,7 @@ router.get("/", isAuthenticated, async (req, res) => {
  * GET /api/projects/:id
  * Get a specific project by ID
  */
-router.get("/:id", isAuthenticated, validateProjectId, async (req, res) => {
+router.get("/:id", isAuthenticated, validateUuid(["id", "projectId"]), async (req, res) => {
   try {
     const rawProjectId = req.params.id;
     
@@ -176,7 +146,7 @@ router.get("/:id", isAuthenticated, validateProjectId, async (req, res) => {
  * PUT /api/projects/:id
  * Update a specific project by ID
  */
-router.put("/:id", isAuthenticated, validateProjectId, async (req, res) => {
+router.put("/:id", isAuthenticated, validateUuid(["id", "projectId"]), async (req, res) => {
   try {
     const rawProjectId = req.params.id;
     console.log('Updating project', rawProjectId, req.body);
@@ -290,7 +260,7 @@ router.put("/:id", isAuthenticated, validateProjectId, async (req, res) => {
  * DELETE /api/projects/:id
  * Delete a specific project by ID
  */
-router.delete("/:id", isAuthenticated, validateProjectId, async (req, res) => {
+router.delete("/:id", isAuthenticated, validateUuid(["id", "projectId"]), async (req, res) => {
   try {
     const rawProjectId = req.params.id;
     

--- a/tests/api/task-toggle-scenarios.test.ts
+++ b/tests/api/task-toggle-scenarios.test.ts
@@ -76,7 +76,7 @@ describe('Task Toggle Endpoint Tests', () => {
   });
 
   // Test 3: Invalid UUID
-  it('should return 404 for invalid UUID', async () => {
+  it('should return 400 for invalid UUID', async () => {
     const response = await request(app)
       .put(`/api/projects/${PROJECT_ID}/tasks/not-a-valid-uuid`)
       .set('x-auth-override', 'true')
@@ -90,7 +90,7 @@ describe('Task Toggle Endpoint Tests', () => {
       body: response.body
     });
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(400);
   });
 
   // Test 4: Cross-project sourceId attempt

--- a/tests/unit/updateBySourceId.test.ts
+++ b/tests/unit/updateBySourceId.test.ts
@@ -139,7 +139,7 @@ describe('Task Update API Hardening Tests', () => {
     
     expect(res.status).toBe(400);
     expect(res.body.success).toBe(false);
-    expect(res.body.error).toBe('INVALID_FORMAT');
+    expect(res.body.error).toBe('INVALID_UUID_FORMAT');
   });
 
   // Scenario 5: Regular non-factor task updates still work


### PR DESCRIPTION
## Summary
- add `validateUuid` middleware
- use `validateUuid` in project and task routes
- update tests for new invalid UUID handling
- tweak imports to match existing style

## Testing
- `npm test` *(fails: useAuth must be used within an AuthProvider)*